### PR TITLE
WIP: Remove cljs output from classpath and serve from tmp-dir when in dev

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -51,7 +51,7 @@
   '[deraen.boot-less      :refer [less]]
   '[deraen.boot-sass      :refer [sass]]
   '[crisptrutski.boot-cljs-test :refer [test-cljs]]
-  '[backend.boot          :refer [start-app]]
+  '[backend.boot          :refer [start-app catch-output]]
   '[reloaded.repl         :refer [go reset start stop system]])
 
 (task-options!
@@ -81,6 +81,7 @@
     ; This starts a repl server with piggieback middleware
     (cljs-repl :ids #{"js/main"})
     (cljs :ids #{"js/main"})
+    (catch-output :paths #{"js/" "css/"})
     (start-app :port port)
     (if speak (boot.task.built-in/speak) identity)))
 

--- a/build.boot
+++ b/build.boot
@@ -73,6 +73,7 @@
    t test-cljs       bool "Compile and run cljs tests"]
   (comp
     (watch)
+    (catch-output :paths #{"js/" "css/"})
     (reload :open-file "vim --servername saapas --remote-silent +norm%sG%s| %s"
             :ids #{"js/main"})
     (if use-sass
@@ -81,7 +82,6 @@
     ; This starts a repl server with piggieback middleware
     (cljs-repl :ids #{"js/main"})
     (cljs :ids #{"js/main"})
-    (catch-output :paths #{"js/" "css/"})
     (start-app :port port)
     (if speak (boot.task.built-in/speak) identity)))
 

--- a/build.boot
+++ b/build.boot
@@ -73,7 +73,12 @@
    t test-cljs       bool "Compile and run cljs tests"]
   (comp
     (watch)
+    ;; It is important that catch-output is the first task, this way all other
+    ;; task can do everything they want with fileset, e.g. reload sees to output js files.
     (catch-output :paths #{"js/" "css/"})
+    ;; Start-app must be after catch-output, so the output directory exists.
+    (start-app :port port)
+    ;; Reload must be before any tasks that write files that should be reloaded.
     (reload :open-file "vim --servername saapas --remote-silent +norm%sG%s| %s"
             :ids #{"js/main"})
     (if use-sass
@@ -82,7 +87,6 @@
     ; This starts a repl server with piggieback middleware
     (cljs-repl :ids #{"js/main"})
     (cljs :ids #{"js/main"})
-    (start-app :port port)
     (if speak (boot.task.built-in/speak) identity)))
 
 (ns-unmap *ns* 'test)

--- a/build.boot
+++ b/build.boot
@@ -31,6 +31,7 @@
                   [javax.servlet/servlet-api "2.5"] ;; Required by ring multipart middleware
                   [compojure "1.5.1"]
                   [hiccup "1.0.5"]
+                  [camel-snake-kebab "0.4.0"] ;; Cljc lib for testing c.t.n refresh
 
                   ; Frontend
                   [reagent "0.6.1-SNAPSHOT" :scope "test"]

--- a/src/clj/backend/boot.clj
+++ b/src/clj/backend/boot.clj
@@ -1,9 +1,11 @@
 (ns backend.boot
-  {:boot/export-tasks true}
   (:require [boot.core :as b]
+            [boot.filesystem :as fs]
+            [ring.util.response :as response]
             [reloaded.repl :refer [go stop]]
-            [backend.main :refer :all]
-            [clojure.tools.namespace.repl :refer [disable-reload!]]))
+            [backend.main :refer [setup-app!]]
+            [clojure.tools.namespace.repl :refer [disable-reload!]])
+  (:import [java.io File]))
 
 (disable-reload!)
 
@@ -18,3 +20,54 @@
                     (do (setup-app! {:port port})
                         (go)))))
       fileset)))
+
+(defonce ^:private output-dir (atom nil))
+
+(defn get-app-output-dir []
+  @output-dir)
+
+(b/deftask catch-output
+  "Copy files in fileset with output role under these paths into
+  a tmp-dir and remove the files from fileset."
+  [p paths PATH #{str} "Paths"]
+  (let [prev (atom nil)]
+
+    (swap! output-dir (fn initialize-output-dir [d] (or d (b/tmp-dir!))))
+
+    (fn middleware [next-task]
+      (fn handler [fileset]
+        (let [prev-output-fileset @prev
+              output-dirs (set (b/output-dirs fileset))
+              [tree output-tree] (reduce-kv (fn [[tree output-tree] k v]
+                                              (if (and (contains? output-dirs (boot.tmpdir/dir v))
+                                                       (some #(.startsWith k %) paths))
+                                                [tree (assoc output-tree k v)]
+                                                [(assoc tree k v) output-tree]))
+                                            [{} {}]
+                                            (:tree fileset))
+              output-fileset (assoc fileset :tree output-tree)]
+
+          (reset! prev output-fileset)
+
+          (try
+            (fs/patch! (fs/->path @output-dir) prev-output-fileset output-fileset :link :tmp)
+            (catch Throwable t
+              (fs/patch! (fs/->path @output-dir) prev-output-fileset output-fileset :link nil)))
+
+          (next-task (b/commit! (assoc fileset :tree tree))))))))
+
+(defn resources
+  "Like compojure.route/resources, but serves files from tmp-dir when used with catch-output task,
+  and else from classpath."
+  [prefix {:keys [root] :as opts}]
+  (if-let [x (some-> (get-app-output-dir) .getPath)]
+    (fn [req]
+      (if (.startsWith (:uri req) prefix)
+        (response/file-response (subs (:uri req) (count prefix)) (assoc opts :root (str x File/separator root)))))
+    (fn [req]
+      (if (.startsWith (:uri req) prefix)
+        (response/resource-response (subs (:uri req) (count prefix)) opts)))))
+
+(comment
+  (get-app-output-dir)
+  ((resources "/js" {:root "js"}) {:uri "/js/main.js"}))

--- a/src/clj/backend/boot.clj
+++ b/src/clj/backend/boot.clj
@@ -60,10 +60,10 @@
   "Like compojure.route/resources, but serves files from tmp-dir when used with catch-output task,
   and else from classpath."
   [prefix {:keys [root] :as opts}]
-  (if-let [x (some-> (get-app-output-dir) .getPath)]
+  (if-let [output-dir (get-app-output-dir)]
     (fn [req]
       (if (.startsWith (:uri req) prefix)
-        (response/file-response (subs (:uri req) (count prefix)) (assoc opts :root (str x File/separator root)))))
+        (response/file-response (subs (:uri req) (count prefix)) (assoc opts :root (.getPath (clojure.java.io/file output-dir root))))))
     (fn [req]
       (if (.startsWith (:uri req) prefix)
         (response/resource-response (subs (:uri req) (count prefix)) opts)))))

--- a/src/clj/backend/server.clj
+++ b/src/clj/backend/server.clj
@@ -1,8 +1,8 @@
 (ns backend.server
   (:require [clojure.java.io :as io]
+            [backend.boot :refer [resources]]
             [com.stuartsierra.component :as component]
             [compojure.core :refer [GET defroutes]]
-            [compojure.route :refer [resources]]
             [compojure.handler :refer [api]]
             [ring.util.response :refer [redirect]]
             [ring.util.http-response :refer :all]

--- a/src/clj/backend/server.clj
+++ b/src/clj/backend/server.clj
@@ -7,7 +7,8 @@
             [ring.util.response :refer [redirect]]
             [ring.util.http-response :refer :all]
             [org.httpkit.server :refer [run-server]]
-            [backend.index :refer [index-page test-page]]))
+            [backend.index :refer [index-page test-page]]
+            [camel-snake-kebab.core :as csk]))
 
 (defroutes routes
   (resources "/js" {:root "js"})

--- a/src/cljs/frontend/core.cljs
+++ b/src/cljs/frontend/core.cljs
@@ -2,7 +2,9 @@
   (:require-macros [frontend.macro :refer [foobar]])
   (:require [reagent.core :as r]
             [common.hello :refer [foo-cljc]]
-            [foo.bar]))
+            [foo.bar]
+            ;; use csk so the cljc files are copied to output
+            [camel-snake-kebab.core :as csk]))
 
 ;; Reagent application state
 ;; Defonce used to that the state is kept between reloads


### PR DESCRIPTION
Catch-output task writes output-files to a tmp-dir and removes them from
fileset. Tmp-dir is used by ring handler to serve files when
catch-output task is used.

Benefits:

- Avoids TNS-45 as ClojureScript output is not in classpath (except for
shortwhile bethween cljs and catch-output task): http://dev.clojure.org/jira/browse/TNS-45
- Classpath state changes during the build pipeline, e.g. it might contain old Cljs output but new Css files. If a error happens during pipeline, the classpath will be left in broken state. Output directory is only updated once the whole pipeline is succesfully run.
    - ClojureScript output is available for browser even during Cljs
compilation
- Only files with output role are served. Classpath also contains input
only files (source-paths): https://github.com/boot-clj/boot/wiki/Filesets#roles-of-files

TODO:

- [x] Boot-reload doesn't see the changes in JavaScript files
- [ ] Test using `target` task together with `sift`. Target can write the output files to a directory in working directory, and `sift` can be used to remove `cljc` files under cljs output directory (other output files would still be kept in classpath).